### PR TITLE
Use error messages when available.

### DIFF
--- a/lib/rpcjson.rb
+++ b/lib/rpcjson.rb
@@ -101,7 +101,7 @@ class RPC
           else
             # No standard for < 2.0 error objects.
             # Bitcoind is 1.1 and seems to follow 2.0 standard, other clients?
-            raise Error.new(answer['error']), 'JSON-RPC Error'
+            raise Error.new(answer['error']), answer['error']['message'] || 'JSON-RPC Error'
           end
         end
 


### PR DESCRIPTION
I want to use this gem in data-web, but I want to see the error messages, hence the fork.
(I also have no objection to using a better gem instead, but this one is working for me at present.)