### PR TITLE
Fixing the invalid gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ Jeweler::Tasks.new do |gem|
   gem.authors = ["Jonathan Jeffus"]
   # Include your dependencies below. Runtime dependencies are required when using your gem,
   # and development dependencies are only needed for development (ie running rake tasks, tests, etc)
-  gem.add_runtime_dependency 'json', '> 0.0'
+  gem.add_runtime_dependency 'json', '>= 0.0'
   #  gem.add_development_dependency 'rspec', '> 1.2.3'
 end
 Jeweler::RubygemsDotOrgTasks.new

--- a/rpcjson.gemspec
+++ b/rpcjson.gemspec
@@ -46,14 +46,12 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.2"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
-      s.add_runtime_dependency(%q<json>, ["> 0.0"])
     else
       s.add_dependency(%q<json>, [">= 0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
       s.add_dependency(%q<rcov>, [">= 0"])
-      s.add_dependency(%q<json>, ["> 0.0"])
     end
   else
     s.add_dependency(%q<json>, [">= 0"])
@@ -61,7 +59,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
     s.add_dependency(%q<rcov>, [">= 0"])
-    s.add_dependency(%q<json>, ["> 0.0"])
   end
 end
 


### PR DESCRIPTION
bundler says that 
The gemspec at
/usr/share/hifi/metaverse/vendor/bundle/ruby/2.1.0/bundler/gems/rpcjson-b65997c16656/rpcjson.gemspec
is not valid. Please fix this gemspec.
The validation error was 'duplicate dependency on json (> 0.0), (>= 0) use:
    add_runtime_dependency 'json', '> 0.0', '>= 0'